### PR TITLE
Regex Update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group 'com.myoutdesk'
-version '1.1-SNAPSHOT'
+version '1.2-TailwindFormatter'
 
 sourceCompatibility = 1.8
 
@@ -22,5 +22,7 @@ intellij {
 }
 patchPluginXml {
     changeNotes """
-      Initial release of Tailwind-Formatter Plugin"""
+    2019-12-05: Fixed issue with tailwind classes containing a slash not being found
+    2019-11-26: Initial release of the Tailwind Formatter plugin.
+    """
 }

--- a/src/main/java/TailwindParser.java
+++ b/src/main/java/TailwindParser.java
@@ -5,7 +5,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class TailwindParser {
-    private final String regex = "\\bclass(?:Name)*\\s*=\\s*([\\\\\"\\']([_a-zA-Z0-9\\s\\-\\:]+)[\\\\\"\\'])";
+    private final String regex = "\\bclass(?:Name)*\\s*=\\s*([\\\\\"\\']([_a-zA-Z0-9\\s\\-\\:\\/]+)[\\\\\"\\'])";
     private TailwindSorter tailwindSorter = new TailwindSorter();
 
     public String processBody(String body)

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -2,9 +2,12 @@
     <id>com.myoutdesk.tailwind_formatter</id>
     <name>Tailwind Formatter</name>
     <vendor email="#" url="https://myoutdesk.com">Tailwind Formatter</vendor>
-    <version>1.1.0</version>
+    <version>1.2.0</version>
     <description>Automatically organizes TailwindCSS classes.</description>
-    <change-notes>Initial release of the Tailwind Formatter plugin.</change-notes>
+    <change-notes>
+        2019-12-05: Fixed issue with tailwind classes containing a slash not being found
+        2019-11-26: Initial release of the Tailwind Formatter plugin.
+    </change-notes>
     <actions>
         <action id="TailwindAction" class="TailwindAction" text="Format Tailwind"
                 description="Format current file with Tailwind Formatter">


### PR DESCRIPTION
### Issue
w-1/3, w-1/2, etc not being properly located in the class list

### Resolution
Updated regex to address issue with TailwindCss classes that contain a slash not being found (w-1/3 for instance). This references a fix done [here](https://github.com/heybourn/headwind/pull/19/commits/c4a85006adf7d71f1855e0ad69b06ac9b498b0cc)