### PR TITLE
Support custom class order via settings

### DIFF
--- a/src/main/java/TailwindAction.java
+++ b/src/main/java/TailwindAction.java
@@ -5,25 +5,34 @@ import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 
-public class TailwindAction extends AnAction {
-    TailwindParser parser = new TailwindParser();
+import java.util.List;
 
+public class TailwindAction extends AnAction {
     public TailwindAction() {
         super("Run Tailwind Formatter");
     }
 
     public void actionPerformed(AnActionEvent event) {
         VirtualFile currentFile = event.getData(CommonDataKeys.VIRTUAL_FILE);
-        if(currentFile == null) {
+        if (currentFile == null) {
             return;
         }
         // Get all the required data from data keys
         final Editor editor = event.getRequiredData(CommonDataKeys.EDITOR);
         final Project project = event.getRequiredData(CommonDataKeys.PROJECT);
         final Document document = editor.getDocument();
+        final TailwindSettings settings = TailwindSettings.getInstance(project);
+
+        final TailwindParser parser = new TailwindParser(new TailwindSorter(getClassOrder(settings)));
         String body = parser.processBody(document.getText());
         WriteCommandAction.runWriteCommandAction(project, () -> {
-                document.setText(body);
+            document.setText(body);
         });
+    }
+
+    private List<String> getClassOrder(TailwindSettings settings) {
+        final List<String> customClassOrder = settings.getCustomClassOrderList();
+
+        return !customClassOrder.isEmpty() ? customClassOrder : new TailwindUtility().classOrder;
     }
 }

--- a/src/main/java/TailwindConfigurable.form
+++ b/src/main/java/TailwindConfigurable.form
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="TailwindConfigurable">
+  <grid id="27dc6" binding="rootPanel" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+    <margin top="0" left="0" bottom="0" right="0"/>
+    <constraints>
+      <xy x="20" y="20" width="534" height="400"/>
+    </constraints>
+    <properties/>
+    <border type="none"/>
+    <children>
+      <grid id="46d1b" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+        <margin top="0" left="0" bottom="0" right="0"/>
+        <constraints>
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+        <border type="empty" title="Custom Class Sort Order:"/>
+        <children>
+          <scrollpane id="21546" class="com.intellij.ui.components.JBScrollPane">
+            <constraints>
+              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="7" hsize-policy="7" anchor="0" fill="3" indent="0" use-parent-layout="false">
+                <preferred-size width="-1" height="40"/>
+              </grid>
+            </constraints>
+            <properties/>
+            <border type="none"/>
+            <children>
+              <component id="1cba5" class="javax.swing.JTextArea" binding="customClassOrderTextArea">
+                <constraints/>
+                <properties/>
+              </component>
+            </children>
+          </scrollpane>
+          <component id="146dd" class="javax.swing.JLabel">
+            <constraints>
+              <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <enabled value="false"/>
+              <text value="One class per line, separated by a newline (\n). Leave empty for default sort order"/>
+            </properties>
+          </component>
+        </children>
+      </grid>
+    </children>
+  </grid>
+</form>

--- a/src/main/java/TailwindConfigurable.java
+++ b/src/main/java/TailwindConfigurable.java
@@ -1,0 +1,41 @@
+import com.intellij.openapi.options.Configurable;
+import com.intellij.openapi.options.ConfigurationException;
+import com.intellij.openapi.project.Project;
+import org.jetbrains.annotations.Nls;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+
+public class TailwindConfigurable implements Configurable, Configurable.NoScroll {
+    private JPanel rootPanel;
+    private JTextArea customClassOrderTextArea;
+    private final TailwindSettings settings;
+
+    public TailwindConfigurable(Project project) {
+        settings = TailwindSettings.getInstance(project);
+    }
+
+    @Nls(capitalization = Nls.Capitalization.Title)
+    @Override
+    public String getDisplayName() {
+        return "Tailwind Formatter";
+    }
+
+    @Nullable
+    @Override
+    public JComponent createComponent() {
+        return this.rootPanel;
+    }
+
+    public boolean isModified() {
+        return !customClassOrderTextArea.getText().equals(settings.getCustomClassOrder());
+    }
+
+    public void apply() throws ConfigurationException {
+        settings.setCustomClassOrder(customClassOrderTextArea.getText().trim());
+    }
+
+    public void reset() {
+        customClassOrderTextArea.setText(settings.getCustomClassOrder());
+    }
+}

--- a/src/main/java/TailwindParser.java
+++ b/src/main/java/TailwindParser.java
@@ -6,21 +6,25 @@ import java.util.regex.Pattern;
 
 public class TailwindParser {
     private final String regex = "\\bclass(?:Name)*\\s*=\\s*([\\\\\"\\']([_a-zA-Z0-9\\s\\-\\:\\/]+)[\\\\\"\\'])";
-    private TailwindSorter tailwindSorter = new TailwindSorter();
+    private final TailwindSorter sorter;
+
+    public TailwindParser(TailwindSorter sorter) {
+        this.sorter = sorter;
+    }
 
     public String processBody(String body)
     {
         Pattern pattern = Pattern.compile(regex, Pattern.MULTILINE);
         Matcher matcher = pattern.matcher(body);
 
-        while(matcher.find()) {
+        while (matcher.find()) {
             // Grab the original entry class="container mx-auto bg-black"...
             String targetReplacement = matcher.group(1);
             // Grab the inner contents of the class list for deduplication and arranging
             String originalClassList = matcher.group(2);
             List<String> currentClasses = Arrays.asList(originalClassList.split(" "));
             // Sort the list of classes
-            currentClasses.sort(tailwindSorter);
+            currentClasses.sort(sorter);
             // Create a linked hash set to remove duplicates
             LinkedHashSet<String> currentClassesWithoutDuplicates = new LinkedHashSet<String>(currentClasses);
             body = body.replace(targetReplacement, "\"" + String.join(" ", currentClassesWithoutDuplicates) + "\"");

--- a/src/main/java/TailwindSettings.java
+++ b/src/main/java/TailwindSettings.java
@@ -1,0 +1,51 @@
+import com.intellij.openapi.components.PersistentStateComponent;
+import com.intellij.openapi.components.ServiceManager;
+import com.intellij.openapi.components.State;
+import com.intellij.openapi.components.Storage;
+import com.intellij.openapi.project.Project;
+import com.intellij.util.xmlb.XmlSerializerUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+@State(name = "TailwindFormatterSettings", storages = {@Storage("tailwind-formatter.xml")})
+public class TailwindSettings implements PersistentStateComponent<TailwindSettings> {
+    @NotNull
+    private String customClassOrder = "";
+
+    public static TailwindSettings getInstance(Project project) {
+        return ServiceManager.getService(project, TailwindSettings.class);
+    }
+
+    @NotNull
+    public String getCustomClassOrder() {
+        return customClassOrder;
+    }
+
+    public void setCustomClassOrder(@NotNull String customClassOrder) {
+        this.customClassOrder = customClassOrder;
+    }
+
+    @NotNull
+    public List<String> getCustomClassOrderList() {
+        if (customClassOrder.isEmpty()) {
+            return new ArrayList<>();
+        }
+
+        return Arrays.asList(customClassOrder.split("\n"));
+    }
+
+    @Nullable
+    @Override
+    public TailwindSettings getState() {
+        return this;
+    }
+
+    @Override
+    public void loadState(@NotNull TailwindSettings state) {
+        XmlSerializerUtil.copyBean(state, this);
+    }
+}

--- a/src/main/java/TailwindSorter.java
+++ b/src/main/java/TailwindSorter.java
@@ -1,12 +1,17 @@
 import java.util.Comparator;
+import java.util.List;
 
 public class TailwindSorter implements Comparator<String> {
-    private TailwindUtility utility = new TailwindUtility();
+    private final List<String> classOrder;
+
+    public TailwindSorter(List<String> classOrder) {
+        this.classOrder = classOrder;
+    }
 
     @Override
     public int compare(String s, String t1) {
-        int positionS = utility.classOrder.indexOf(s);
-        int positionT1 = utility.classOrder.indexOf(t1);
+        int positionS = classOrder.indexOf(s);
+        int positionT1 = classOrder.indexOf(t1);
         if(positionS == -1) {
             positionS = 9999;
         }

--- a/src/main/java/TailwindSorter.java
+++ b/src/main/java/TailwindSorter.java
@@ -3,9 +3,11 @@ import java.util.List;
 
 public class TailwindSorter implements Comparator<String> {
     private final List<String> classOrder;
+    private final int lastPosition;
 
     public TailwindSorter(List<String> classOrder) {
         this.classOrder = classOrder;
+        this.lastPosition = classOrder.size();
     }
 
     @Override
@@ -13,10 +15,10 @@ public class TailwindSorter implements Comparator<String> {
         int positionS = classOrder.indexOf(s);
         int positionT1 = classOrder.indexOf(t1);
         if(positionS == -1) {
-            positionS = 9999;
+            positionS = lastPosition;
         }
         if(positionT1 == -1) {
-            positionT1 = 9999;
+            positionT1 = lastPosition;
         }
         return positionS - positionT1;
     }

--- a/src/main/java/TailwindUtility.java
+++ b/src/main/java/TailwindUtility.java
@@ -1,4 +1,3 @@
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -14,4 +14,8 @@
         </action>
     </actions>
     <depends>com.intellij.modules.platform</depends>
+    <extensions defaultExtensionNs="com.intellij">
+        <projectService serviceImplementation="TailwindSettings"/>
+        <projectConfigurable instance="TailwindConfigurable" groupId="tools"/>
+    </extensions>
 </idea-plugin>

--- a/src/test/java/TestSorter.java
+++ b/src/test/java/TestSorter.java
@@ -15,7 +15,7 @@ public class TestSorter {
         List<String> shuffledOrder = utility.classOrder;
         Collections.shuffle(shuffledOrder);
         Assert.assertNotEquals(originalOrder, shuffledOrder);
-        shuffledOrder.sort(new TailwindSorter());
+        shuffledOrder.sort(new TailwindSorter(new TailwindUtility().classOrder));
         Assert.assertEquals(originalOrder, shuffledOrder);
     }
 }


### PR DESCRIPTION
This PR adds support for defining a custom class order via a settings page so you can properly sort custom classes that were added via the `tailwind.config.js`. I missed this feature a lot when doing Tailwind stuff in IntelliJ products compared to using VSCode and headwind.

_Disclaimer: I'm not doing a lot of Java and IntelliJ plugin development is new to me, so please let me know if I messed up something :) I used the Jetbrains docs and other plugins as references_

Right now it's a simple JTextArea (which is good enough for me), but I also played around with using an `EditorEx` instance to get highlighting for a JSON array of strings to work, but I wasn't sure how to properly import the stored JSON string since `import org.json.*` doesn't seem to be available in this project (right now). Also using `PsiFile.createFileFromText` seemed like a bit too much for this case (if that would've even worked).

So if you prefer sth. like [this](https://user-images.githubusercontent.com/502368/79761261-7ba82d00-8321-11ea-8cd0-36b10c163348.png) I'll need some guidance how to properly integrate JSON 🙂 otherwise it will look like this (current PR state) ⬇️ 

<img width="1028" alt="image" src="https://user-images.githubusercontent.com/502368/79751451-e3a34700-8312-11ea-97b9-6b82fef6f149.png">

The advantage of storing a JSON array would be much better user experience for users that are moving between Jetbrains IDEs and VSCode and would like to transfer their class order.

If this is likely to be merged I'll update the readme and changelog