### PR TITLE
Fix settings merge and custom class order sorting

### DIFF
--- a/src/main/java/TailwindAction.java
+++ b/src/main/java/TailwindAction.java
@@ -5,9 +5,9 @@ import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 
-public class TailwindAction extends AnAction {
-    TailwindParser parser = new TailwindParser();
+import java.util.List;
 
+public class TailwindAction extends AnAction {
     public TailwindAction() {
         super("Run Tailwind Formatter");
     }
@@ -21,9 +21,17 @@ public class TailwindAction extends AnAction {
         final Editor editor = event.getRequiredData(CommonDataKeys.EDITOR);
         final Project project = event.getRequiredData(CommonDataKeys.PROJECT);
         final Document document = editor.getDocument();
+        final TailwindSettings settings = TailwindSettings.getInstance(project);
+        final TailwindParser parser = new TailwindParser(new TailwindSorter(getClassOrder(settings)));
         String body = parser.processBody(document.getText());
         WriteCommandAction.runWriteCommandAction(project, () -> {
             document.setText(body);
         });
+    }
+
+    private List<String> getClassOrder(TailwindSettings settings) {
+        final List<String> customClassOrder = settings.getCustomClassOrderList();
+
+        return !customClassOrder.isEmpty() ? customClassOrder : new TailwindUtility().classOrder;
     }
 }

--- a/src/main/java/TailwindParser.java
+++ b/src/main/java/TailwindParser.java
@@ -7,7 +7,11 @@ import java.util.regex.Pattern;
 public class TailwindParser {
     private final String classNamesRegex = "[_a-zA-Z0-9\\s\\-\\:\\/]+";
     private final String regex = "\\bclass(?:Name)*\\s*=\\s*(?:[\\\"\\'](?<classList1>" + classNamesRegex + ")[\\\"\\'])|@apply (?<classList2>" + classNamesRegex + ");";
-    private TailwindSorter tailwindSorter = new TailwindSorter();
+    private final TailwindSorter sorter;
+
+    public TailwindParser(TailwindSorter sorter) {
+        this.sorter = sorter;
+    }
 
     public String processBody(String body) {
         Pattern pattern = Pattern.compile(regex, Pattern.MULTILINE);
@@ -32,7 +36,7 @@ public class TailwindParser {
 
             final List<String> currentClasses = Arrays.asList(originalClassList.trim().split(" +"));
             // Sort the list of classes
-            currentClasses.sort(tailwindSorter);
+            currentClasses.sort(sorter);
             // Create a linked hash set to remove duplicates
             final LinkedHashSet<String> currentClassesWithoutDuplicates = new LinkedHashSet<String>(currentClasses);
             body = body.replace(

--- a/src/main/java/TailwindSorter.java
+++ b/src/main/java/TailwindSorter.java
@@ -1,17 +1,24 @@
 import java.util.Comparator;
+import java.util.List;
 
 public class TailwindSorter implements Comparator<String> {
-    private TailwindUtility utility = new TailwindUtility();
+    private final List<String> classOrder;
+    private final int lastPosition;
+
+    public TailwindSorter(List<String> classOrder) {
+        this.classOrder = classOrder;
+        this.lastPosition = classOrder.size();
+    }
 
     @Override
     public int compare(String s, String t1) {
-        int positionS = utility.classOrder.indexOf(s);
-        int positionT1 = utility.classOrder.indexOf(t1);
+        int positionS = classOrder.indexOf(s);
+        int positionT1 = classOrder.indexOf(t1);
         if(positionS == -1) {
-            positionS = 9999;
+            positionS = lastPosition;
         }
         if(positionT1 == -1) {
-            positionT1 = 9999;
+            positionT1 = lastPosition;
         }
         return positionS - positionT1;
     }

--- a/src/test/java/TestParser.java
+++ b/src/test/java/TestParser.java
@@ -1,0 +1,40 @@
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Arrays;
+
+public class TestParser {
+
+    @Test
+    public void testProcessBody() {
+        TailwindParser parser = new TailwindParser();
+
+        Arrays.asList("html", "css").forEach(ext -> {
+            String input = "";
+            String expected = "";
+
+            try {
+                input = readFixtureFile("input." + ext);
+                expected = readFixtureFile("expected." + ext);
+            } catch (IOException | URISyntaxException e) {
+                Assert.fail("Could not load fixture file: " + e);
+            }
+
+            Assert.assertEquals(expected, parser.processBody(input));
+        });
+    }
+
+    private String readFixtureFile(String file) throws IOException, URISyntaxException {
+        return new String(
+                Files.readAllBytes(
+                        Paths.get(
+                                TestParser.class.getResource("/fixtures/" + file).toURI()
+                        )
+                )
+        );
+    }
+}

--- a/src/test/java/TestParser.java
+++ b/src/test/java/TestParser.java
@@ -11,7 +11,7 @@ public class TestParser {
 
     @Test
     public void testProcessBody() {
-        TailwindParser parser = new TailwindParser();
+        TailwindParser parser = new TailwindParser(new TailwindSorter(new TailwindUtility().classOrder));
 
         Arrays.asList("html", "css").forEach(ext -> {
             String input = "";

--- a/src/test/java/TestSorter.java
+++ b/src/test/java/TestSorter.java
@@ -15,7 +15,7 @@ public class TestSorter {
         List<String> shuffledOrder = utility.classOrder;
         Collections.shuffle(shuffledOrder);
         Assert.assertNotEquals(originalOrder, shuffledOrder);
-        shuffledOrder.sort(new TailwindSorter());
+        shuffledOrder.sort(new TailwindSorter(new TailwindUtility().classOrder));
         Assert.assertEquals(originalOrder, shuffledOrder);
     }
 }

--- a/src/test/resources/fixtures/expected.css
+++ b/src/test/resources/fixtures/expected.css
@@ -1,0 +1,21 @@
+.test-1 {
+    @apply container font-bold bg-blue-500 c-unknown-3 a-unknown-1 b-unknown-2;
+}
+
+.test-2 {
+    @apply container font-bold bg-blue-500 a-unknown-1 c-unknown-3 b-unknown-2;
+}
+
+.test-3 {
+    @apply container font-bold bg-blue-500 a-unknown-1 c-unknown-3 random b-unknown-2;
+}
+
+.multiline-ignored {
+    @apply
+        unknown-and-ignored
+        container
+        a-unknown-1
+        font-bold
+        bg-blue-500
+    ;
+}

--- a/src/test/resources/fixtures/expected.html
+++ b/src/test/resources/fixtures/expected.html
@@ -1,0 +1,16 @@
+<div class="text-xs text-base font-bold leading-tight uppercase"></div>
+<div class="text-xs text-base font-bold leading-tight text-red-400 uppercase"></div>
+
+<div class="container font-bold bg-blue-500 c-unknown-3 a-unknown-1 b-unknown-2"></div>
+
+<div class="container font-bold bg-blue-500 a-unknown-1 c-unknown-3 b-unknown-2"></div>
+
+<div class="container font-bold bg-blue-500 a-unknown-1 c-unknown-3 random b-unknown-2"></div>
+
+<div class="
+    unknown-and-ignored
+    container
+    a-unknown-1
+    font-bold
+    bg-blue-500
+"></div>

--- a/src/test/resources/fixtures/input.css
+++ b/src/test/resources/fixtures/input.css
@@ -1,0 +1,21 @@
+.test-1 {
+    @apply c-unknown-3 container a-unknown-1 font-bold b-unknown-2 bg-blue-500;
+}
+
+.test-2 {
+    @apply  font-bold a-unknown-1 c-unknown-3 b-unknown-2  container bg-blue-500 ;
+}
+
+.test-3 {
+    @apply    font-bold a-unknown-1 c-unknown-3 random    b-unknown-2  container bg-blue-500  ;
+}
+
+.multiline-ignored {
+    @apply
+        unknown-and-ignored
+        container
+        a-unknown-1
+        font-bold
+        bg-blue-500
+    ;
+}

--- a/src/test/resources/fixtures/input.html
+++ b/src/test/resources/fixtures/input.html
@@ -1,0 +1,16 @@
+<div class="text-xs font-bold leading-tight uppercase text-base"></div>
+<div class="text-xs font-bold leading-tight uppercase text-base text-red-400"></div>
+
+<div class="c-unknown-3 container a-unknown-1 font-bold b-unknown-2 bg-blue-500"></div>
+
+<div class=" font-bold a-unknown-1 c-unknown-3 b-unknown-2  container bg-blue-500 "></div>
+
+<div class="   font-bold a-unknown-1 c-unknown-3 random    b-unknown-2  container bg-blue-500  "></div>
+
+<div class="
+    unknown-and-ignored
+    container
+    a-unknown-1
+    font-bold
+    bg-blue-500
+"></div>


### PR DESCRIPTION
Hey, after upgrading to the approved plugin release I noticed that the configured class order did not work anymore. Upon closer inspection it seems that quite some code from #13 was lost during manually merging in #17.

This PR re-adds that code and should make the configured class order work again