### PR TITLE
Fix formatting classes with single quotes in HTML files

### DIFF
--- a/src/test/java/TestParser.java
+++ b/src/test/java/TestParser.java
@@ -6,12 +6,22 @@ import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.List;
 
 public class TestParser {
+    private final List<String> classOrder = Arrays.asList(
+        "first",
+        "sm:first",
+        "sec_ond",
+        "THIRD",
+        "lg:hover:last",
+        "group-focus:la-st",
+        "last"
+    );
 
     @Test
     public void testProcessBody() {
-        TailwindParser parser = new TailwindParser(new TailwindSorter(new TailwindUtility().classOrder));
+        TailwindParser parser = new TailwindParser(new TailwindSorter(this.classOrder));
 
         Arrays.asList("html", "css").forEach(ext -> {
             String input = "";

--- a/src/test/resources/fixtures/expected.css
+++ b/src/test/resources/fixtures/expected.css
@@ -1,21 +1,15 @@
 .test-1 {
-    @apply container font-bold bg-blue-500 c-unknown-3 a-unknown-1 b-unknown-2;
+    @apply first sm:first sec_ond THIRD lg:hover:last group-focus:la-st last unknown2 unknown1;
 }
 
 .test-2 {
-    @apply container font-bold bg-blue-500 a-unknown-1 c-unknown-3 b-unknown-2;
-}
-
-.test-3 {
-    @apply container font-bold bg-blue-500 a-unknown-1 c-unknown-3 random b-unknown-2;
+    @apply first sm:first sec_ond THIRD lg:hover:last group-focus:la-st last unknown2 unknown1;
 }
 
 .multiline-ignored {
     @apply
         unknown-and-ignored
-        container
         a-unknown-1
-        font-bold
-        bg-blue-500
+        first
     ;
 }

--- a/src/test/resources/fixtures/expected.html
+++ b/src/test/resources/fixtures/expected.html
@@ -1,16 +1,17 @@
-<div class="text-xs text-base font-bold leading-tight uppercase"></div>
-<div class="text-xs text-base font-bold leading-tight text-red-400 uppercase"></div>
+<div class="first sm:first sec_ond THIRD lg:hover:last group-focus:la-st last"></div>
+<div class="first sm:first sec_ond THIRD lg:hover:last group-focus:la-st last unknown"></div>
 
-<div class="container font-bold bg-blue-500 c-unknown-3 a-unknown-1 b-unknown-2"></div>
+<div class="first sm:first sec_ond THIRD lg:hover:last group-focus:la-st last unknown2 unknown1"></div>
+<div class='first sm:first sec_ond THIRD lg:hover:last group-focus:la-st last unknown2 unknown1'></div>
 
-<div class="container font-bold bg-blue-500 a-unknown-1 c-unknown-3 b-unknown-2"></div>
+<div className="first sm:first sec_ond THIRD lg:hover:last group-focus:la-st last unknown2 unknown1"></div>
+<div className='first sm:first sec_ond THIRD lg:hover:last group-focus:la-st last unknown2 unknown1'></div>
 
-<div class="container font-bold bg-blue-500 a-unknown-1 c-unknown-3 random b-unknown-2"></div>
+<div class="first sm:first sec_ond THIRD lg:hover:last group-focus:la-st last unknown2 unknown1"></div>
+<div class='first sm:first sec_ond THIRD lg:hover:last group-focus:la-st last unknown2 unknown1'></div>
 
 <div class="
     unknown-and-ignored
-    container
     a-unknown-1
-    font-bold
-    bg-blue-500
+    first
 "></div>

--- a/src/test/resources/fixtures/input.css
+++ b/src/test/resources/fixtures/input.css
@@ -1,21 +1,15 @@
 .test-1 {
-    @apply c-unknown-3 container a-unknown-1 font-bold b-unknown-2 bg-blue-500;
+    @apply THIRD unknown2 sm:first unknown1 group-focus:la-st first last sec_ond lg:hover:last;
 }
 
 .test-2 {
-    @apply  font-bold a-unknown-1 c-unknown-3 b-unknown-2  container bg-blue-500 ;
-}
-
-.test-3 {
-    @apply    font-bold a-unknown-1 c-unknown-3 random    b-unknown-2  container bg-blue-500  ;
+    @apply   THIRD   unknown2 sm:first     unknown1 group-focus:la-st  first last sec_ond   lg:hover:last   ;
 }
 
 .multiline-ignored {
     @apply
         unknown-and-ignored
-        container
         a-unknown-1
-        font-bold
-        bg-blue-500
+        first
     ;
 }

--- a/src/test/resources/fixtures/input.html
+++ b/src/test/resources/fixtures/input.html
@@ -1,16 +1,17 @@
-<div class="text-xs font-bold leading-tight uppercase text-base"></div>
-<div class="text-xs font-bold leading-tight uppercase text-base text-red-400"></div>
+<div class="THIRD sm:first group-focus:la-st first last sec_ond lg:hover:last"></div>
+<div class="THIRD sm:first group-focus:la-st first last sec_ond lg:hover:last unknown"></div>
 
-<div class="c-unknown-3 container a-unknown-1 font-bold b-unknown-2 bg-blue-500"></div>
+<div class="THIRD unknown2 sm:first unknown1 group-focus:la-st first last sec_ond lg:hover:last"></div>
+<div class='THIRD unknown2 sm:first unknown1 group-focus:la-st first last sec_ond lg:hover:last'></div>
 
-<div class=" font-bold a-unknown-1 c-unknown-3 b-unknown-2  container bg-blue-500 "></div>
+<div className="THIRD unknown2 sm:first unknown1 group-focus:la-st first last sec_ond lg:hover:last"></div>
+<div className='THIRD unknown2 sm:first unknown1 group-focus:la-st first last sec_ond lg:hover:last'></div>
 
-<div class="   font-bold a-unknown-1 c-unknown-3 random    b-unknown-2  container bg-blue-500  "></div>
+<div class="   THIRD   unknown2 sm:first     unknown1 group-focus:la-st  first last sec_ond   lg:hover:last   "></div>
+<div class='   THIRD   unknown2 sm:first     unknown1 group-focus:la-st  first last sec_ond   lg:hover:last   '></div>
 
 <div class="
     unknown-and-ignored
-    container
     a-unknown-1
-    font-bold
-    bg-blue-500
+    first
 "></div>


### PR DESCRIPTION
Fixes #24 

This extracts the used quotes and uses them later when building the sorted class list. I also used a custom class order list in tests to be more manageable and testable with various class strings